### PR TITLE
Add Consumer Hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ type resultStruct struct {
 func main() {
 	p := pool.NewPool(4, 16)
 
+	// can add a consumer hook for each consumer routine to get a value from
+	// such as a database connection which each job can reuse via job.HookParam()
+	// p.AddConsumerHook(func() interface{}{ return db connection or whatever})
+	
 	fn := func(job *pool.Job) {
 
 		i := job.Params()[0].(int)
@@ -116,6 +120,10 @@ import (
 
 func main() {
 	p := pool.NewPool(4, 16)
+
+	// can add a consumer hook for each consumer routine to get a value from
+	// such as a database connection which each job can reuse via job.HookParam()
+	// p.AddConsumerHook(func() interface{}{ return db connection or whatever})
 
 	fn := func(job *pool.Job) {
 

--- a/pool_test.go
+++ b/pool_test.go
@@ -52,6 +52,34 @@ func TestPool(t *testing.T) {
 	Equal(t, count, 4)
 }
 
+func TestConsumerHook(t *testing.T) {
+
+	pool := NewPool(4, 4)
+	pool.AddConsumerHook(func() interface{} { return 1 })
+
+	fn := func(job *Job) {
+
+		j := job.HookParam().(int)
+		job.Return(j)
+	}
+
+	for i := 0; i < 4; i++ {
+		pool.Queue(fn)
+	}
+
+	var count int
+
+	for v := range pool.Results() {
+		count++
+
+		val, ok := v.(int)
+		Equal(t, ok, true)
+		Equal(t, val, 1)
+	}
+
+	Equal(t, count, 4)
+}
+
 func TestCancel(t *testing.T) {
 
 	pool := NewPool(2, 4)


### PR DESCRIPTION
- now can register ConsumerHook function that will be run while firing up the consumer routines and that return value will be set/passed to each job. This is particularily usefull when creating a saving pool so a the consumer hook would create a database connection for each job to reuse instead of creating an additional one for each job.
