### PR TITLE
FIX: p.cancel might be closed twice

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -164,8 +164,12 @@ func (p *Pool) Queue(fn JobFunc, params ...interface{}) {
 // Cancel cancels all jobs not already running.
 // It can also be called from within a job through the Job object
 func (p *Pool) Cancel() {
-	close(p.cancel)
 	p.cancelLock.Lock()
+	if p.cancelled {
+		p.cancelLock.Unlock()
+		return
+	}
+	close(p.cancel)
 	p.cancelled = true
 	p.cancelLock.Unlock()
 	p.cancelJobs()


### PR DESCRIPTION
`Cancel()` might be invoked several times by the woker goroutines got an error at the same time,
as a result the `p.cancel` will be closed more than once.

I have fixed this issue by checking the p.cancelled before closing the p.cancel.

```
 [recovered]
    panic: close of closed channel

goroutine 2033 [running]:
panic(0x583320, 0xc820279120)
    /usr/local/Cellar/go/1.6.2/libexec/src/runtime/panic.go:481 +0x3e6
go.planetmeican.com/libra/util/pool.(*Pool).Cancel(0xc82008d3e0)
    /Users/zzz/go/src/go.planetmeican.com/libra/util/pool/pool.go:167 +0x25
go.planetmeican.com/libra/util/pool.(*Pool).Queue.func1.1.1(0xc82008d3e0)
    /Users/zzz/go/src/go.planetmeican.com/libra/util/pool/pool.go:117 +0x286
panic(0x670ec0, 0xc820017c80)
    /usr/local/Cellar/go/1.6.2/libexec/src/runtime/panic.go:443 +0x4e9
go.planetmeican.com/libra/service.BatchMigrateUser.func1(0xc82031ce80)
    /Users/zzz/go/src/go.planetmeican.com/libra/service/migrate.go:125 +0x1a0
go.planetmeican.com/libra/util/pool.(*Pool).Queue.func1.1(0xc82008d3e0)
    /Users/zzz/go/src/go.planetmeican.com/libra/util/pool/pool.go:136 +0x1b4
created by go.planetmeican.com/libra/util/pool.(*Pool).Queue.func1
    /Users/zzz/go/src/go.planetmeican.com/libra/util/pool/pool.go:142 +0x49
exit status 2
```
